### PR TITLE
feat: add new validator format

### DIFF
--- a/.changelog/59.txt
+++ b/.changelog/59.txt
@@ -1,0 +1,23 @@
+```release-note:feature
+`stringvalidator` - Add new `format` validator to validate strings against specific formats (e.g., Base64, UUIDv4, URN ).
+```
+
+```release-note:feature
+`stringvalidator/format` - Add new function `IsBase64` to validate if a string is a valid Base64 encoded string.
+```
+
+```release-note:feature
+`stringvalidator/format` - Add new function `IsUUIDv4` to validate if a string is a valid UUIDv4.
+```
+
+```release-note:feature
+`stringvalidator/format` - Add new function `IsURN` to validate if a string is a valid URN.
+```
+
+```release-note:note
+`stringvalidator` - The validator `IsUUID` has been deprecated in favor of `format.IsUUIDv4`. It will be removed in the next major release.
+```
+
+```release-note:note
+`stringvalidator` - The validator `IsURN` has been deprecated in favor of `format.IsURN`. It will be removed in the next major release.
+```

--- a/docs/stringvalidator/cases.md
+++ b/docs/stringvalidator/cases.md
@@ -6,7 +6,7 @@ hide:
 
 !!! quote inline end "Released in v1.12.0"
 
-This validator is a generic validator for checking if the string is a valid network format.
+This validator is used to check if the string contains or does not contain certain characters.
 
 ## How to use it
 

--- a/docs/stringvalidator/formats.md
+++ b/docs/stringvalidator/formats.md
@@ -1,0 +1,119 @@
+---
+hide:
+    - navigation
+---
+# `Formats`
+
+The Formats validator is a flexible utility designed to validate whether a given string adheres to specific predefined formats. It supports multiple validation types, enabling you to ensure strings meet requirements such as Base64 encoding, UUIDs, etc...
+
+## How to use it
+
+The validator accepts a list of FormatsValidatorType values, which specify the formats to validate. You can include one or more of the following options:
+
+* `IsBase64` - Check if the string is a valid Base64 encoded string.
+* `IsUUIDv4` - Check if the string is a valid (v4) UUID.
+* `IsURN` - Check if the string is a valid URN.
+
+### Example IsBase64
+
+The following example demonstrates how to use the validator to check if a string is a valid Base64-encoded value.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "content_encoded": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "Content for ...",
+                Validators: []validator.String{
+                    fstringvalidator.Formats(
+                        []fstringvalidator.FormatsValidatorType{
+                            fstringvalidator.IsBase64,
+                        }, 
+                        false,
+                    ),
+                },
+            },
+```
+
+### Example IsUUIDv4
+
+The following example demonstrates how to use the validator to check if a string is a valid version 4 (v4) UUID.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {  
+    resp.Schema = schema.Schema{  
+        (...)  
+        "uuid": schema.StringAttribute{  
+            Optional:            true,  
+            MarkdownDescription: "Unique identifier (UUID v4) for the resource.",  
+            Validators: []validator.String{  
+                fstringvalidator.Formats(  
+                    []fstringvalidator.FormatsValidatorType{  
+                        fstringvalidator.IsUUIDv4,  
+                    }, 
+                    false,
+                ),
+            },
+        },
+        (...)
+    }
+}
+```
+
+### Example IsURN
+
+The following example will check if the string is a valid URN.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "urn": schema.StringAttribute{
+            Optional:            true,
+            MarkdownDescription: "Uniform Resource Name (URN) for the resource.",
+            Validators: []validator.String{
+                fstringvalidator.Formats(
+                    []fstringvalidator.FormatsValidatorType{
+                        fstringvalidator.IsURN,
+                    }, 
+                    false,
+                ),
+            },
+        },
+        (...)
+    }
+}
+```
+
+### Example with multiple formats checks
+
+The Formats validator can also be used to validate multiple formats at once. You can combine different formats in a single validator by passing them as a slice of FormatsValidatorType values. This allows you to check if a string is valid for any of the specified formats.
+
+The following example demonstrates how to use the validator to check if a string is a valid URN value **OR** a valid version 4 (v4) UUID.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "ids": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "IDS can be an urn or uuid format ...",
+                Validators: []validator.String{
+                    fstringvalidator.Formats(
+                        []fstringvalidator.FormatsValidatorType{
+                            fstringvalidator.IsURN,
+                            fstringvalidator.IsUUIDv4,
+                        }, 
+                        true,
+                    ),
+                },
+            },
+        (...)
+    }
+}
+```

--- a/docs/stringvalidator/index.md
+++ b/docs/stringvalidator/index.md
@@ -33,10 +33,11 @@ import (
 
 ### String
 
-- [`IsURN`](isurn.md) - This validator is used to check if the string is a valid URN.
-- [`IsUUID`](isuuid.md) - This validator is used to check if the string is a valid UUID.
+- [`IsURN`](isurn.md) - (**DEPRECATED**) This validator is used to check if the string is a valid URN (Use `Formats` validator instead).
+- [`IsUUID`](isuuid.md) - (**DEPRECATED**) This validator is used to check if the string is a valid UUID (Use `Formats` validator instead).
 - [`PrefixContains`](prefixcontains.md) - This validator is used to check if the string contains prefix in the given value.
 - [`Cases`](cases.md) - This validator is a generic validator for checking if the string respects a case.
+- [`Formats`](formats.md) - This validator is a generic validator for checking if the string respects of a format.
 
 ### Special
 

--- a/docs/stringvalidator/isurn.md
+++ b/docs/stringvalidator/isurn.md
@@ -6,6 +6,10 @@ hide:
 
 !!! quote inline end "Released in v1.1.0"
 
+!!! warning
+
+    Now this validator is deprecated, please use `formats.IsURN` instead
+
 This validator is used to check if the string is a valid URN.
 
 ## How to use it
@@ -15,11 +19,14 @@ This validator is used to check if the string is a valid URN.
 func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
     resp.Schema = schema.Schema{
         (...)
-            "vm_id": schema.StringAttribute{
-                Optional:            true,
-                MarkdownDescription: "The VM ID for ...",
-                Validators: []validator.String{
-                    fstringvalidator.IsValidURN()
-                },
+            "urn": schema.StringAttribute{
+            Optional:            true,
+            MarkdownDescription: "Uniform Resource Name (URN) for the resource.",
+            Validators: []validator.String{
+                fstringvalidator.IsValidURN()
             },
+        },
+        (...)
+    }
+}
 ```

--- a/docs/stringvalidator/isuuid.md
+++ b/docs/stringvalidator/isuuid.md
@@ -6,6 +6,10 @@ hide:
 
 !!! quote inline end "Released in v1.1.0"
 
+!!! warning
+
+    Now this validator is deprecated, please use `formats.IsUUIDv4` instead
+
 This validator is used to check if the string is a valid (v4) UUID.
 
 ## How to use it
@@ -15,11 +19,14 @@ This validator is used to check if the string is a valid (v4) UUID.
 func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
     resp.Schema = schema.Schema{
         (...)
-            "vm_id": schema.StringAttribute{
-                Optional:            true,
-                MarkdownDescription: "The VM ID for ...",
-                Validators: []validator.String{
-                    fstringvalidator.IsValidUUID()
-                },
+            "uuid": schema.StringAttribute{  
+            Optional:            true,  
+            MarkdownDescription: "Unique identifier (UUID v4) for the resource.",  
+            Validators: []validator.String{
+                fstringvalidator.IsValidUUID()
             },
+        },
+        (...)
+    }
+}
 ```

--- a/stringvalidator/formats.go
+++ b/stringvalidator/formats.go
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package stringvalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/formatstypes"
+)
+
+var _ validator.String = formatsValidator{}
+
+const (
+	FormatsIsBase64 FormatsValidatorType = "is_base64"
+	FormatsIsUUIDv4 FormatsValidatorType = "is_uuid_v4"
+	FormatsIsURN    FormatsValidatorType = "is_urn"
+)
+
+var formatsTypesFunc = map[FormatsValidatorType]func() validator.String{
+	FormatsIsBase64: formatstypes.IsBase64,
+	FormatsIsUUIDv4: formatstypes.IsUUIDv4,
+	FormatsIsURN:    formatstypes.IsURN,
+}
+
+type FormatsValidatorType string
+
+type formatsValidator struct {
+	FormatsTypes []FormatsValidatorType
+	ComparatorOR bool
+}
+
+// Description describes the validation in plain text formatsting.
+func (validatorFormats formatsValidator) Description(ctx context.Context) string {
+	description := ""
+
+	if len(validatorFormats.FormatsTypes) == 0 {
+		description += "invalid configuration"
+	}
+
+	switch {
+	case !validatorFormats.ComparatorOR && len(validatorFormats.FormatsTypes) > 1:
+		description += "The value must respect at least one of the following rules :\n"
+	case validatorFormats.ComparatorOR && len(validatorFormats.FormatsTypes) > 1:
+		description += "The value must respect all of the following rules :\n"
+	case len(validatorFormats.FormatsTypes) == 1:
+		description += "The value must respect the following rule : "
+	}
+
+	for i, formatsType := range validatorFormats.FormatsTypes {
+		if i == len(validatorFormats.FormatsTypes)-1 {
+			description += formatsTypesFunc[formatsType]().Description(ctx)
+		} else {
+			description += formatsTypesFunc[formatsType]().Description(ctx) + ", "
+		}
+	}
+
+	return description
+}
+
+// MarkdownDescription describes the validation in Markdown formatsting.
+func (validatorFormats formatsValidator) MarkdownDescription(ctx context.Context) string {
+	return validatorFormats.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validatorFormats formatsValidator) ValidateString(
+	ctx context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if len(validatorFormats.FormatsTypes) == 0 {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"No configuration provided",
+			fmt.Sprintf("invalid value: %s", request.ConfigValue.String()),
+		)
+		return
+	}
+
+	diags := diag.Diagnostics{}
+
+	// Check if the formats type is valid
+	// and call the validation function for each formats type
+	// and append the diagnostics to the response
+	// If the formats type is not valid, return an error
+	for _, formatsType := range validatorFormats.FormatsTypes {
+		d := new(validator.StringResponse)
+		if _, ok := formatsTypesFunc[formatsType]; !ok {
+			response.Diagnostics.AddError(
+				"Invalid formats type",
+				fmt.Sprintf("invalid formats type: %s", formatsType),
+			)
+			return
+		}
+		formatsTypesFunc[formatsType]().ValidateString(ctx, request, d)
+		diags.Append(d.Diagnostics...)
+	}
+
+	// Check if the value is valid for at least one of the formats types if comparatorOR is true
+	if validatorFormats.ComparatorOR && diags.ErrorsCount() == len(validatorFormats.FormatsTypes) {
+		response.Diagnostics.AddError(
+			fmt.Sprintf("Invalid configuration for attribute %s", request.Path),
+			"Set at least one valid formats type",
+		)
+	}
+
+	// If the value is valid for all of the formats types if comparatorOR is false (So AND logic)
+	if !validatorFormats.ComparatorOR {
+		response.Diagnostics.Append(diags...)
+	}
+}
+
+/*
+NewFormatsValidator creates a new FormatsValidator.
+It takes a list of formats types and a boolean comparatorOR.
+If comparatorOR is true, the value must be at least one of the formats types.
+If comparatorOR is false, the value must be all of the formats types.
+If no formats types are provided, the validator will return an error.
+The formats types are defined in the formatsTypes package.
+*/
+func Formats(formatsTypes []FormatsValidatorType, comparatorOR bool) validator.String {
+	return &formatsValidator{
+		FormatsTypes: formatsTypes,
+		ComparatorOR: comparatorOR,
+	}
+}

--- a/stringvalidator/formats_test.go
+++ b/stringvalidator/formats_test.go
@@ -1,0 +1,188 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package stringvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator"
+)
+
+func TestFormatsValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		typesOfFormats []stringvalidator.FormatsValidatorType
+		val            types.String
+		expectError    bool
+		ComparatorOR   bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"invalid-base64": {
+			val: types.StringValue("invalidBase64"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsBase64,
+			},
+			expectError: true,
+		},
+		"valid-base64": {
+			val: types.StringValue("dmFsaWQK"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsBase64,
+			},
+		},
+		"invalid-uuid": {
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+			},
+			expectError: true,
+		},
+		"valid-uuid": {
+			val: types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+			},
+		},
+		"valid-urn": {
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsURN,
+			},
+		},
+		"invalid-urn": {
+			val: types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsURN,
+			},
+			expectError: true,
+		},
+		"no-validator": {
+			val:            types.StringValue("dmFsaWQK"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{},
+			expectError:    true,
+		},
+		"invalid-validator": {
+			val: types.StringValue("dmFsaWQK"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				"invalid",
+			},
+			expectError: true,
+		},
+		"valid-uuid-or-urn": {
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+				stringvalidator.FormatsIsURN,
+			},
+			ComparatorOR: true,
+			expectError:  false,
+		},
+		"invalid-uuid-or-urn": {
+			val: types.StringValue("urn:dmFsaWQK-not-a-uuid"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+				stringvalidator.FormatsIsURN,
+			},
+			ComparatorOR: true,
+			expectError:  true,
+		},
+		"invalid-uuid-and-urn": {
+			val: types.StringValue("urn:dmFsaWQK-not-a-uuid"),
+			typesOfFormats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+				stringvalidator.FormatsIsURN,
+			},
+			ComparatorOR: false,
+			expectError:  true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			stringvalidator.Formats(test.typesOfFormats, test.ComparatorOR).ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestFormatsValidatorDescription(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		description  string
+		Formats      []stringvalidator.FormatsValidatorType
+		ComparatorOR bool
+	}
+	tests := map[string]testCase{
+		"base64": {
+			description: "The value must respect the following rule : must be a valid base64 string",
+			Formats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsBase64,
+			},
+		},
+		"uuid": {
+			description: "The value must respect the following rule : must be a valid UUID v4",
+			Formats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+			},
+		},
+		"urn": {
+			description: "The value must respect the following rule : must be a valid URN",
+			Formats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsURN,
+			},
+		},
+		"uuid-or-urn": {
+			description: "The value must respect at least one of the following rules :\nmust be a valid UUID v4, must be a valid URN",
+			Formats: []stringvalidator.FormatsValidatorType{
+				stringvalidator.FormatsIsUUIDv4,
+				stringvalidator.FormatsIsURN,
+			},
+			ComparatorOR: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			validator := stringvalidator.Formats(test.Formats, false)
+			if validator.Description(context.Background()) != test.description {
+				t.Fatalf("got unexpected description: %s != %s", validator.Description(context.Background()), test.description)
+			}
+
+			if validator.MarkdownDescription(context.Background()) != test.description {
+				t.Fatalf("got unexpected description: %s != %s", validator.MarkdownDescription(context.Background()), test.description)
+			}
+		})
+	}
+}

--- a/stringvalidator/formatstypes/base64.go
+++ b/stringvalidator/formatstypes/base64.go
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = base64Validator{}
+
+type base64Validator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator base64Validator) Description(_ context.Context) string {
+	return "must be a valid base64 string"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator base64Validator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator base64Validator) ValidateString(
+	_ context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	if _, err := base64.StdEncoding.DecodeString(request.ConfigValue.ValueString()); err != nil {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Failed to parse base64 string",
+			fmt.Sprintf("invalid value: %s", request.ConfigValue.String()),
+		)
+	}
+}

--- a/stringvalidator/formatstypes/base64_test.go
+++ b/stringvalidator/formatstypes/base64_test.go
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/formatstypes"
+)
+
+func TestBase64Validator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("dGVzdA=="),
+		},
+		"invalid": {
+			val:         types.StringValue("dGVzdA"),
+			expectError: true,
+		},
+		"invalid_with_numeric": {
+			val:         types.StringValue("invalidBase64"),
+			expectError: true,
+		},
+		"invalid_with_space": {
+			val:         types.StringValue("AVec eSPace"),
+			expectError: true,
+		},
+		"invalid_with_special_char": {
+			val:         types.StringValue("AVecSPecialCh@r"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			formatstypes.IsBase64().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatal("expected no error, got error")
+			}
+		})
+	}
+}

--- a/stringvalidator/formatstypes/types.go
+++ b/stringvalidator/formatstypes/types.go
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes
+
+import "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+type Validator interface {
+	validator.String
+}

--- a/stringvalidator/formatstypes/urn.go
+++ b/stringvalidator/formatstypes/urn.go
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/common"
+)
+
+var _ validator.String = &urnValidator{}
+
+type urnValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator urnValidator) Description(_ context.Context) string {
+	return "must be a valid URN"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator urnValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator urnValidator) ValidateString(
+	ctx context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Use the common regex validator to validate the URN format
+	// and add the error message if it doesn't match
+	// the expected URN format.
+	regexValidator := common.RegexValidator{
+		Desc:         "must be a valid URN",
+		Regex:        `(?m)urn:[A-Za-z0-9][A-Za-z0-9-]{0,31}:([A-Za-z0-9()+,\-.:=@;$_!*']|%[0-9A-Fa-f]{2})+`,
+		ErrorSummary: "Failed to parse URN",
+		ErrorDetail:  "This value is not a valid URN",
+	}
+	regexValidator.ValidateString(ctx, request, response)
+	if response.Diagnostics.HasError() {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Failed to parse URN",
+			"This value is not a valid URN",
+		)
+	}
+}

--- a/stringvalidator/formatstypes/urn_test.go
+++ b/stringvalidator/formatstypes/urn_test.go
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/formatstypes"
+)
+
+func TestValidURNValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+		},
+		"invalid": {
+			val:         types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			expectError: true,
+		},
+		"multiple byte characters": {
+			// Rightwards Arrow Over Leftwards Arrow (U+21C4; 3 bytes)
+			val:         types.StringValue("⇄"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			formatstypes.IsURN().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}

--- a/stringvalidator/formatstypes/uuid.go
+++ b/stringvalidator/formatstypes/uuid.go
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/common"
+)
+
+var _ validator.String = uuidValidator{}
+
+type uuidValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator uuidValidator) Description(_ context.Context) string {
+	return "must be a valid UUID v4"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator uuidValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator uuidValidator) ValidateString(
+	ctx context.Context,
+	request validator.StringRequest,
+	response *validator.StringResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Use the common regex validator to validate the UUID format
+	// and add the error message if it doesn't match
+	// the expected UUID format.
+	regexValidator := common.RegexValidator{
+		Desc: "must be a valid UUID",
+		// UUID v4 regex pattern
+		// https://www.ietf.org/rfc/rfc9562.txt
+		// explain: https://www.bortzmeyer.org/9562.html
+		Regex:        `(?m)^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$`,
+		ErrorSummary: "Failed to parse UUID",
+		ErrorDetail:  "This value is not a valid (v4) UUID",
+	}
+	regexValidator.ValidateString(ctx, request, response)
+}

--- a/stringvalidator/formatstypes/uuid_test.go
+++ b/stringvalidator/formatstypes/uuid_test.go
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-plugin-framework-validators/stringvalidator/formatstypes"
+)
+
+func TestValidUUIDValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"valid": {
+			val: types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b12"),
+		},
+		"invalid string": {
+			val:         types.StringValue("urn:test:demo:4aeb40d8-038c-4e77-8181-a7054f583b12"),
+			expectError: true,
+		},
+		"invalid uuid": {
+			val:         types.StringValue("4aeb40d8-038c-4e77-8181-a7054f583b"),
+			expectError: true,
+		},
+		"multiple byte characters": {
+			// Rightwards Arrow Over Leftwards Arrow (U+21C4; 3 bytes)
+			val:         types.StringValue("⇄"),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				ConfigValue: test.val,
+			}
+			response := validator.StringResponse{}
+			formatstypes.IsUUIDv4().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}

--- a/stringvalidator/formatstypes/validators.go
+++ b/stringvalidator/formatstypes/validators.go
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package formatstypes
+
+import "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+/*
+IsBase64 returns a validator which ensures that the configured attribute
+value is a valid base64 string with base64.StdEncoding package.
+
+Null (unconfigured) and unknown (known after apply) values are skipped.
+*/
+func IsBase64() validator.String {
+	return &base64Validator{}
+}
+
+/*
+IsUUIDv4 returns a validator which ensures that the configured attribute
+value is a valid UUID v4 string.
+
+Null (unconfigured) and unknown (known after apply) values are skipped.
+*/
+func IsUUIDv4() validator.String {
+	return &uuidValidator{}
+}
+
+/*
+IsURN returns a validator which ensures that the configured attribute
+value is a valid URN string.
+
+Null (unconfigured) and unknown (known after apply) values are skipped.
+*/
+func IsURN() validator.String {
+	return &urnValidator{}
+}


### PR DESCRIPTION
This pull request introduces a new `Format` validator for string validation in the `stringvalidator` package, along with support for specific formats like Base64, UUID, and URN. It includes the implementation of the validator, examples in documentation, and comprehensive test coverage.

### New `Format` Validator Implementation:
* Added the `Format` validator to validate strings against specific formats (e.g., Base64, UUID, URN) using a modular design. (`stringvalidator/format.go`)
* Defined individual format validators (`IsBase64`, `IsUUID`, `IsURN`) with their respective validation logic. (`stringvalidator/format/base64.go`, `stringvalidator/format/uuid.go`, `stringvalidator/format/urn.go`) [[1]](diffhunk://#diff-c74cef6256bce21c1c67b77f0e17259dd73fd28e2eedb57516493f89c7c12124R1-R51) [[2]](diffhunk://#diff-d89049fac4682f40796fe632e42a397442314b55fd62e62ec14191a3e697a7f0R1-R61) [[3]](diffhunk://#diff-7fc52af607d8743eb050129ffd9c77947b9449f555b4c13852b01eba3d2fd74bR1-R61)
* Added a common interface for format validators. (`stringvalidator/format/types.go`)

### Documentation:
* Updated documentation to include usage examples for the `Format` validator and its supported formats. (`docs/stringvalidator/format.md`)
* Clarified the purpose of the `Cases` validator in the existing documentation. (`docs/stringvalidator/cases.md`)

### Test Coverage:
* Added unit tests for individual format validators (`Base64`, `UUID`, `URN`) to ensure correctness. (`stringvalidator/format/base64_test.go`, `stringvalidator/format/uuid_test.go`, `stringvalidator/format/urn_test.go`) [[1]](diffhunk://#diff-f40cf18aae236db8940fb4300aab32148e34d946d56e81e137aaf186ba70f6eeR1-R74) [[2]](diffhunk://#diff-3a7f3023d4518ee862e6753357e6b6544dc3b8db6badc5bd9b5bb30a1de066d4R1-R72) [[3]](diffhunk://#diff-5a25cb3108bfaef454252dd652beec8b1036fd36a558d2b42fd970d13b643917R1-R68)
* Added integration tests for the `Format` validator to validate its behavior with multiple formats and error scenarios. (`stringvalidator/format_test.go`)