### PR TITLE
docs: improve Formats documentation and add depreciation

### DIFF
--- a/.changelog/62.txt
+++ b/.changelog/62.txt
@@ -1,0 +1,7 @@
+```release-note:note
+`stringvalidator` - Updated deprecation warnings for IsURN and IsUUID to use the new `urn` and `uuid` validators.
+```
+
+```release-note:note
+`stringvalidator` - Fix documentation for formats functions to use the correct function names.
+```

--- a/docs/stringvalidator/formats.md
+++ b/docs/stringvalidator/formats.md
@@ -29,7 +29,7 @@ func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *
                 Validators: []validator.String{
                     fstringvalidator.Formats(
                         []fstringvalidator.FormatsValidatorType{
-                            fstringvalidator.IsBase64,
+                            fstringvalidator.FormatsIsBase64,
                         }, 
                         false,
                     ),
@@ -52,7 +52,7 @@ func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *
             Validators: []validator.String{  
                 fstringvalidator.Formats(  
                     []fstringvalidator.FormatsValidatorType{  
-                        fstringvalidator.IsUUIDv4,  
+                        fstringvalidator.FormatsIsUUIDv4,  
                     }, 
                     false,
                 ),
@@ -78,7 +78,7 @@ func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *
             Validators: []validator.String{
                 fstringvalidator.Formats(
                     []fstringvalidator.FormatsValidatorType{
-                        fstringvalidator.IsURN,
+                        fstringvalidator.FormatsIsURN,
                     }, 
                     false,
                 ),
@@ -106,8 +106,8 @@ func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *
                 Validators: []validator.String{
                     fstringvalidator.Formats(
                         []fstringvalidator.FormatsValidatorType{
-                            fstringvalidator.IsURN,
-                            fstringvalidator.IsUUIDv4,
+                            fstringvalidator.FormatsIsURN,
+                            fstringvalidator.FormatsIsUUIDv4,
                         }, 
                         true,
                     ),

--- a/docs/stringvalidator/isurn.md
+++ b/docs/stringvalidator/isurn.md
@@ -8,7 +8,7 @@ hide:
 
 !!! warning
 
-    Now this validator is deprecated, please use `formats.IsURN` instead
+    Now this validator is deprecated, please use `FormatsIsURN` instead
 
 This validator is used to check if the string is a valid URN.
 

--- a/docs/stringvalidator/isuuid.md
+++ b/docs/stringvalidator/isuuid.md
@@ -8,7 +8,7 @@ hide:
 
 !!! warning
 
-    Now this validator is deprecated, please use `formats.IsUUIDv4` instead
+    Now this validator is deprecated, please use `FormatsIsUUIDv4` instead
 
 This validator is used to check if the string is a valid (v4) UUID.
 

--- a/stringvalidator/urn.go
+++ b/stringvalidator/urn.go
@@ -21,6 +21,9 @@ returns a validator which ensures that the configured attribute
 value is a valid URN.
 
 Null (unconfigured) and unknown (known after apply) values are skipped.
+
+Deprecated: This function is deprecated and will be removed in a future version.
+Use `FormatsIsURN` instead.
 */
 func IsURN() validator.String {
 	return &common.RegexValidator{

--- a/stringvalidator/uuid.go
+++ b/stringvalidator/uuid.go
@@ -21,6 +21,9 @@ returns a validator which ensures that the configured attribute
 value is a valid (v4) UUID.
 
 Null (unconfigured) and unknown (known after apply) values are skipped.
+
+Deprecated: This function is deprecated and will be removed in a future version.
+Use `FormatsIsUUIDv4` instead.
 */
 func IsUUID() validator.String {
 	return &common.RegexValidator{


### PR DESCRIPTION
This pull request updates string validator functions to use new naming conventions and deprecates older functions. It also updates documentation to reflect these changes and adds deprecation warnings to the codebase.

### Updates to Validator Functions:
* Replaced `fstringvalidator.IsBase64` with `fstringvalidator.FormatsIsBase64` in `docs/stringvalidator/formats.md`.
* Replaced `fstringvalidator.IsUUIDv4` with `fstringvalidator.FormatsIsUUIDv4` in `docs/stringvalidator/formats.md`.
* Replaced `fstringvalidator.IsURN` with `fstringvalidator.FormatsIsURN` in `docs/stringvalidator/formats.md`.
* Updated combined validators to use `FormatsIsURN` and `FormatsIsUUIDv4` instead of their older counterparts in `docs/stringvalidator/formats.md`.

### Documentation Changes:
* Updated deprecation warnings in `docs/stringvalidator/isurn.md` to recommend `FormatsIsURN` instead of `formats.IsURN`.
* Updated deprecation warnings in `docs/stringvalidator/isuuid.md` to recommend `FormatsIsUUIDv4` instead of `formats.IsUUIDv4`.

### Deprecation Notices:
* Added a deprecation warning to the `IsURN` function in `stringvalidator/urn.go`, recommending the use of `FormatsIsURN`.
* Added a deprecation warning to the `IsUUID` function in `stringvalidator/uuid.go`, recommending the use of `FormatsIsUUID`.